### PR TITLE
Update README.md to show the installation option for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ python setup.py install
 Full installation instuctions, including installation of dependencies, can be found at
 [bempp.com/installation.html](https://bempp.com/installation.html).
 
+On Arch Linux bempp-cl can be installed using the [AUR package](https://aur.archlinux.org/packages/python-bempp-cl).
+
 ## Documentation
 Full documentation of Bempp can be found at [bempp.com/documentation](https://bempp.com/documentation/index.html)
 and in [the Bempp Handbook](https://bempp.com/handbook).


### PR DESCRIPTION
Recently I have installed bempp-cl on Arch Linux and created a AUR package for it. Arch Linux users can easily install it using that package, so I added one line in the README.md to show that option, hope that it is useful.