### PR TITLE
Prioritise device interface specified by operator.

### DIFF
--- a/bempp/api/fmm/exafmm.py
+++ b/bempp/api/fmm/exafmm.py
@@ -191,7 +191,13 @@ class ExafmmInterface(object):
 
     @classmethod
     def from_grid(
-        cls, source_grid, mode, wavenumber=None, target_grid=None, precision="double"
+        cls,
+        source_grid,
+        mode,
+        wavenumber=None,
+        target_grid=None,
+        precision="double",
+        device_interface=None,
     ):
         """
         Initialise an Exafmm instance from a given source and target grid.
@@ -210,6 +216,9 @@ class ExafmmInterface(object):
         precision : string
             Either 'single' or 'double'. Currently, the Fmm is always
             executed in double precision.
+        device_interface : string
+            Either 'numba' or 'opencl'. If not provided, the DEFAULT_DEVICE_INTERFACE
+            will be used for the calculation of local interactions.
         """
         import bempp.api
         from bempp.api.integration.triangle_gauss import rule
@@ -247,6 +256,7 @@ class ExafmmInterface(object):
                     np.array([], dtype="float64"),
                     precision,
                     False,
+                    device_interface,
                 )
             elif mode == "helmholtz":
                 singular_correction = get_local_interaction_operator(
@@ -258,6 +268,7 @@ class ExafmmInterface(object):
                     ),
                     precision,
                     True,
+                    device_interface,
                 )
             elif mode == "modified_helmholtz":
                 singular_correction = get_local_interaction_operator(
@@ -267,6 +278,7 @@ class ExafmmInterface(object):
                     np.array([wavenumber], dtype="float64"),
                     precision,
                     False,
+                    device_interface,
                 )
         return cls(
             source_points,

--- a/bempp/api/fmm/fmm_assembler.py
+++ b/bempp/api/fmm/fmm_assembler.py
@@ -23,7 +23,7 @@ def get_mode_from_operator_identifier(identifier):
         raise ValueError("Unknown identifier string.")
 
 
-def get_fmm_interface(domain, dual_to_range, mode, wavenumber):
+def get_fmm_interface(domain, dual_to_range, mode, wavenumber, device_interface=None):
     """Get an Fmm instance."""
     import bempp.api
 
@@ -37,7 +37,11 @@ def get_fmm_interface(domain, dual_to_range, mode, wavenumber):
         from bempp.api.fmm.exafmm import ExafmmInterface
 
         interface = ExafmmInterface.from_grid(
-            domain.grid, mode, wavenumber=wavenumber, target_grid=dual_to_range.grid
+            domain.grid,
+            mode,
+            wavenumber=wavenumber,
+            target_grid=dual_to_range.grid,
+            device_interface=device_interface,
         )
         _FMM_CACHE[key] = interface
     else:
@@ -193,7 +197,7 @@ class FmmAssembler(_assembler.AssemblerBase):
             raise ValueError(f"Unknown value {mode} for `mode`.")
 
         fmm_interface = get_fmm_interface(
-            actual_domain, actual_dual_to_range, mode, wavenumber
+            actual_domain, actual_dual_to_range, mode, wavenumber, device_interface
         )
 
         self._evaluator = create_evaluator(

--- a/bempp/api/fmm/helpers.py
+++ b/bempp/api/fmm/helpers.py
@@ -150,7 +150,13 @@ def helmholtz_kernel(
 
 
 def get_local_interaction_operator(
-    grid, local_points, kernel_function, kernel_parameters, precision, is_complex
+    grid,
+    local_points,
+    kernel_function,
+    kernel_parameters,
+    precision,
+    is_complex,
+    device_interface=None,
 ):
     """Get the local interaction operator."""
     import bempp.api
@@ -192,7 +198,9 @@ def get_local_interaction_operator(
         )
 
     elif GLOBAL_PARAMETERS.fmm.near_field_representation == "evaluate":
-        if bempp.api.DEFAULT_DEVICE_INTERFACE == "numba":
+        if device_interface is None:
+            device_interface = bempp.api.DEFAULT_DEVICE_INTERFACE
+        if device_interface == "numba":
             evaluator = get_local_interaction_evaluator_numba(
                 grid.data(precision),
                 local_points.astype(dtype),
@@ -204,7 +212,7 @@ def get_local_interaction_operator(
             return LinearOperator(
                 shape=(rows, cols), matvec=evaluator, dtype=result_type
             )
-        elif bempp.api.DEFAULT_DEVICE_INTERFACE == "opencl":
+        elif device_interface == "opencl":
             evaluator = get_local_interaction_evaluator_opencl(
                 grid,
                 local_points.astype(dtype),
@@ -217,9 +225,7 @@ def get_local_interaction_operator(
                 shape=(rows, cols), matvec=evaluator, dtype=result_type
             )
         else:
-            raise ValueError(
-                "DEFAULT_DEVICE_INTERFACE must be one of 'numba', 'opencl'."
-            )
+            raise ValueError("Device interface must be one of 'numba', 'opencl'.")
     else:
         raise ValueError("Unknown value for near_field_representation.")
 

--- a/bempp/core/dispatcher.py
+++ b/bempp/core/dispatcher.py
@@ -16,7 +16,7 @@ def singular_assembler_dispatcher(device_interface, *args):
         singular_assembler(device_interface, *args)
 
     else:
-        raise ValueError("Unknown assembler.")
+        raise ValueError("Device interface must be one of 'numba', 'opencl'.")
 
 
 def dense_assembler_dispatcher(device_interface, *args):
@@ -34,7 +34,7 @@ def dense_assembler_dispatcher(device_interface, *args):
         dense_assembler(device_interface, *args)
 
     else:
-        raise ValueError("Unknown assembler.")
+        raise ValueError("Device interface must be one of 'numba', 'opencl'.")
 
 
 def potential_dispatcher(device_interface, *args):
@@ -52,4 +52,4 @@ def potential_dispatcher(device_interface, *args):
         return potential_assembler(device_interface, *args)
 
     else:
-        raise ValueError("Unknown assembler.")
+        raise ValueError("Device interface must be one of 'numba', 'opencl'.")


### PR DESCRIPTION
The local interactions in the FMM assembler need to be calculated by either numba or opencl routines. Instead of using the default device interface from the global parameters, prioritise the device interface specified upon creation of the boundary integral operator.