### PR TITLE
Changes to allow the use of various FMM instances with different parameters (ncrit, expansion order)

### DIFF
--- a/bempp/api/fmm/exafmm.py
+++ b/bempp/api/fmm/exafmm.py
@@ -197,6 +197,7 @@ class ExafmmInterface(object):
         wavenumber=None,
         target_grid=None,
         precision="double",
+        parameters=None,
         device_interface=None,
     ):
         """
@@ -216,6 +217,8 @@ class ExafmmInterface(object):
         precision : string
             Either 'single' or 'double'. Currently, the Fmm is always
             executed in double precision.
+        parameters  :   object
+            A bempp parameters object. If not provided, the GLOBAL_PARAMETERS will be used.
         device_interface : string
             Either 'numba' or 'opencl'. If not provided, the DEFAULT_DEVICE_INTERFACE
             will be used for the calculation of local interactions.
@@ -225,7 +228,9 @@ class ExafmmInterface(object):
         from bempp.api.fmm.helpers import get_local_interaction_operator
         import numpy as np
 
-        quadrature_order = bempp.api.GLOBAL_PARAMETERS.quadrature.regular
+        parameters = bempp.api.assign_parameters(parameters)
+
+        quadrature_order = parameters.quadrature.regular
 
         local_points, weights = rule(quadrature_order)
 
@@ -285,9 +290,9 @@ class ExafmmInterface(object):
             target_points,
             mode,
             wavenumber=wavenumber,
-            depth=bempp.api.GLOBAL_PARAMETERS.fmm.depth,
-            expansion_order=bempp.api.GLOBAL_PARAMETERS.fmm.expansion_order,
-            ncrit=bempp.api.GLOBAL_PARAMETERS.fmm.ncrit,
+            depth=parameters.fmm.depth,
+            expansion_order=parameters.fmm.expansion_order,
+            ncrit=parameters.fmm.ncrit,
             precision=precision,
             singular_correction=singular_correction,
         )

--- a/bempp/api/fmm/fmm_assembler.py
+++ b/bempp/api/fmm/fmm_assembler.py
@@ -23,13 +23,16 @@ def get_mode_from_operator_identifier(identifier):
         raise ValueError("Unknown identifier string.")
 
 
-def get_fmm_interface(domain, dual_to_range, mode, wavenumber, device_interface=None):
+def get_fmm_interface(domain, dual_to_range, mode, wavenumber, parameters=None, device_interface=None):
     """Get an Fmm instance."""
     import bempp.api
 
     global _FMM_CACHE
 
-    key = (domain.grid.id, dual_to_range.grid.id, mode, wavenumber)
+    parameters = bempp.api.assign_parameters(parameters)
+
+    key = (domain.grid.id, dual_to_range.grid.id, mode, wavenumber, parameters.fmm.expansion_order,
+           parameters.fmm.ncrit)
 
     interface = _FMM_CACHE.get(key, None)
 
@@ -41,6 +44,7 @@ def get_fmm_interface(domain, dual_to_range, mode, wavenumber, device_interface=
             mode,
             wavenumber=wavenumber,
             target_grid=dual_to_range.grid,
+            parameters=parameters,
             device_interface=device_interface,
         )
         _FMM_CACHE[key] = interface
@@ -197,7 +201,7 @@ class FmmAssembler(_assembler.AssemblerBase):
             raise ValueError(f"Unknown value {mode} for `mode`.")
 
         fmm_interface = get_fmm_interface(
-            actual_domain, actual_dual_to_range, mode, wavenumber, device_interface
+            actual_domain, actual_dual_to_range, mode, wavenumber, self.parameters, device_interface
         )
 
         self._evaluator = create_evaluator(

--- a/bempp/api/fmm/fmm_assembler.py
+++ b/bempp/api/fmm/fmm_assembler.py
@@ -23,7 +23,9 @@ def get_mode_from_operator_identifier(identifier):
         raise ValueError("Unknown identifier string.")
 
 
-def get_fmm_interface(domain, dual_to_range, mode, wavenumber, parameters=None, device_interface=None):
+def get_fmm_interface(
+    domain, dual_to_range, mode, wavenumber, parameters=None, device_interface=None
+):
     """Get an Fmm instance."""
     import bempp.api
 
@@ -31,8 +33,14 @@ def get_fmm_interface(domain, dual_to_range, mode, wavenumber, parameters=None, 
 
     parameters = bempp.api.assign_parameters(parameters)
 
-    key = (domain.grid.id, dual_to_range.grid.id, mode, wavenumber, parameters.fmm.expansion_order,
-           parameters.fmm.ncrit)
+    key = (
+        domain.grid.id,
+        dual_to_range.grid.id,
+        mode,
+        wavenumber,
+        parameters.fmm.expansion_order,
+        parameters.fmm.ncrit,
+    )
 
     interface = _FMM_CACHE.get(key, None)
 
@@ -201,7 +209,12 @@ class FmmAssembler(_assembler.AssemblerBase):
             raise ValueError(f"Unknown value {mode} for `mode`.")
 
         fmm_interface = get_fmm_interface(
-            actual_domain, actual_dual_to_range, mode, wavenumber, self.parameters, device_interface
+            actual_domain,
+            actual_dual_to_range,
+            mode,
+            wavenumber,
+            self.parameters,
+            device_interface,
         )
 
         self._evaluator = create_evaluator(


### PR DESCRIPTION
I have modified the code so that the expansion order and ncrit now form part of the key for the cache of the FMM instances, and also so the parameters used will be those passed to the boundary operator when created, if these are provided, or it will take the global parameters at the time of the assembly of the boundary operator object. I have tested this myself and believe that it is functioning correctly.

We used this idea in https://arxiv.org/abs/2108.10481 to implement a low accuracy Calderón preconditioner, and think it might be useful in other cases.

Open to your thoughts and suggestions. Thanks!

Stefan Search