### PR TITLE
Wider search of gmsh on Windows.

### DIFF
--- a/bempp/api/__init__.py
+++ b/bempp/api/__init__.py
@@ -219,6 +219,8 @@ def _gmsh_path():
 
     if _os.name == "nt":
         gmp = which("gmsh.exe")
+        if gmp is None:
+            gmp = which("gmsh")
     else:
         gmp = which("gmsh")
     if gmp is None:


### PR DESCRIPTION
When Gmsh is installed through Pip on Windows, the executable is called 'gmsh' instead of 'gmsh.exe', so a wider search of the gmsh path is necessary.