### PR TITLE
Inconsistent naming in Maxwell-dielectric notebook 

### DIFF
--- a/notebooks/maxwell/maxwell_dielectric.ipynb
+++ b/notebooks/maxwell/maxwell_dielectric.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "In this notebook, we consider the bistatic radar cross section generated from plane wave scattering by an array of dielectric spheres $\\Omega_j$, each with its individual permittivity $\\epsilon_j$ and permeability $\\mu_j$.\n",
     "\n",
-    "We denote by $\\epsilon_{0}$ and $\\mu_0$ the electric permittivity and magnetic permeability in vacuum, and by $\\epsilon_{r, j} = \\frac{\\epsilon_j}{\\epsilon_0}$ and $\\mu_{r, j} = \\frac{\\mu_j}{\\mu_0}$ the relative permittivity and relative permeability for each dielectric object. Denote by $\\mathbf{E}^\\text{s}$, $\\mathbf{H}^\\text{s}$ the scattered electric and magnetic field in the exterior of the scatterers. Moreover, let $\\mathbf{E}$ and $\\mathbf{H}$ be the total exterior fields. Correspondingly, we denote the interior fields in the $j$th obstacle by $\\mathbf{E}_j$ and $\\mathbf{H}_j$.\n",
+    "We denote by $\\epsilon_{0}$ and $\\mu_0$ the electric permittivity and magnetic permeability in vacuum, and by $\\epsilon_{r, j} = \\frac{\\epsilon_j}{\\epsilon_0}$ and $\\mu_{r, j} = \\frac{\\mu_j}{\\mu_0}$ the relative permittivity and relative permeability for each dielectric object. Denote by $\\mathbf{E}^\\text{s}$, $\\mathbf{H}^\\text{s}$ the scattered electric and magnetic field in the exterior of the scatterers. Moreover, let $\\mathbf{E}^{+}$ and $\\mathbf{H}^{+}$ be the total exterior fields. Correspondingly, we denote the interior fields in the $j$th obstacle by $\\mathbf{E}_j$ and $\\mathbf{H}_j$.\n",
     "\n",
     "For a given medium, the Maxwell equations are given by\n",
     "\\begin{align}\n",
@@ -28,7 +28,7 @@
     "\\nabla\\times\\nabla\\times \\mathbf{E}^{+}(x) - k_0^2\\mathbf{E}^{+}(x) &= 0,~x\\in\\Omega^{+}\\nonumber\\\\\n",
     "\\nabla\\times\\nabla \\times \\mathbf{E}_{j}(x) - k_j^2\\mathbf{E}_{j}(x) &= 0,~x\\in\\Omega_j\\nonumber\\\\\n",
     "\\end{align}\n",
-    "with $k_0 = \\omega\\sqrt{\\epsilon_0\\mu_0}$ and $k_j = k_0\\sqrt{\\epsilon_{r,j}\\mu_{r,j}}$. We define the normal trace  $\\gamma_t\\mathbf{E} = \\mathbf{E}\\times n$ and the Neumann trace $\\gamma_N = \\frac{1}{ik}\\gamma_t\\left[\\nabla\\times \\mathbf{E}\\right]$. The exterior field $\\mathbf{E}^{s}$ is the sum of the incident wave $\\mathbf{E}^{inc}$ and the scattered wave $\\mathbf{E}^{s}$.\n",
+    "with $k_0 = \\omega\\sqrt{\\epsilon_0\\mu_0}$ and $k_j = k_0\\sqrt{\\epsilon_{r,j}\\mu_{r,j}}$. We define the rotated tangential trace  $\\gamma_t\\mathbf{E} = \\mathbf{E}\\times n$ and the Neumann trace $\\gamma_N = \\frac{1}{ik}\\gamma_t\\left[\\nabla\\times \\mathbf{E}\\right]$. The exterior field $\\mathbf{E}^{+}$ is the sum of the incident wave $\\mathbf{E}^{inc}$ and the scattered wave $\\mathbf{E}^{s}$.\n",
     "\n",
     "\n",
     "Now let $ V := \\begin{bmatrix}\\gamma_t \\mathbf{E}\\\\ \\rho\\gamma_N\\mathbf{E}\\end{bmatrix}$, where $\\rho := \\sqrt{\\epsilon_r}/\\sqrt{\\mu_r}$. With $V_j^{+}$ being the exterior trace data (using $\\epsilon_0$ and $\\mu_0$) on the boundary the $j$th scatterer, and $V_j^{-}$ the corresponding interior trace data (using $\\epsilon_{r, j}$ and $\\mu_{r, j}$) the correct boundary condition for this scattering problem is\n",
@@ -43,7 +43,7 @@
     "$$\n",
     "\\begin{bmatrix}\\frac{1}{2}I + A_j^{-}\\end{bmatrix}V_j^{-} = V_j^{-}\n",
     "$$ \n",
-    "with $A_j^{-}$ being the scaled multitrace operator for the interior problem and $V_j^{-}$ the corresponding interior trace data. Using the boundary conditions $V_j^{-} = V_j^{+}$ and the fact that $V_j^{inc} = V_j^{+} + V_j^{s}$ for the trace data $V_j^{inc}$ of the incident wave the interior and exterior equations combined result in\n",
+    "with $A_j^{-}$ being the scaled multitrace operator for the interior problem and $V_j^{-}$ the corresponding interior trace data. Using the boundary conditions $V_j^{-} = V_j^{+}$ and the fact that $V_j^{inc} = V_j^{+} - V_j^{s}$ for the trace data $V_j^{inc}$ of the incident wave the interior and exterior equations combined result in\n",
     "$$\n",
     "\\begin{bmatrix}A_j^{-} + A_j^{+}\\end{bmatrix}V_j^{+} + \\sum_{i\\neq j}A_{j, i}V_i^{+} = V_j^{inc}.\n",
     "$$\n",
@@ -436,7 +436,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -450,7 +450,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi!

I found some inconsistencies with the naming used at the beginning of the Maxwell-dielectric notebook; in particular:

- Changed inconsistent naming for exterior fields. 
- Sign relating incident, scattered and total fields seems to have a typo.
- The rotated tangential trace was referred to as normal.

That's it!