### PR TITLE
Update viewers.py

### DIFF
--- a/bempp_cl/api/external/viewers.py
+++ b/bempp_cl/api/external/viewers.py
@@ -153,7 +153,18 @@ def visualize_with_gmsh(obj, mode=None, transformation=None):
         )
     outfile.close()
 
-    subprocess.Popen([GMSH_PATH, outfile.name])
+    ## important change for running of windows GUI
+    import shutil
+    import os
+
+    gmsh_path = shutil.which("gmsh")
+    env = os.environ.copy()
+    if gmsh_path.lower().endswith(".bat"):
+        subprocess.Popen(f'"{gmsh_path}" "{outfile.name}"', shell=True, env=env)
+    else:
+        subprocess.Popen([gmsh_path, outfile.name], env=env)
+
+    #subprocess.Popen([GMSH_PATH, outfile.name])
 
 
 def visualize_with_paraview(obj, mode=None, transformation=None):

--- a/bempp_cl/api/external/viewers.py
+++ b/bempp_cl/api/external/viewers.py
@@ -3,7 +3,6 @@
 import numpy as _np
 
 
-
 def visualize(obj, mode=None, transformation=None):
     """
     Create a visualisation.
@@ -234,4 +233,3 @@ def enable_jupyter_viewer():
     import bempp_cl.api
 
     bempp_cl.api.PLOT_BACKEND = "jupyter_notebook"
-    

--- a/bempp_cl/api/external/viewers.py
+++ b/bempp_cl/api/external/viewers.py
@@ -1,8 +1,7 @@
 """Define interfaces to external viewers."""
 
 import numpy as _np
-import shutil
-import os
+
 
 
 def visualize(obj, mode=None, transformation=None):
@@ -138,6 +137,8 @@ def visualize_with_gmsh(obj, mode=None, transformation=None):
     import subprocess
     from bempp_cl.api import export, GMSH_PATH, TMP_PATH, GridFunction
     from bempp_cl.api.grid.grid import Grid
+    import shutil
+    import os
 
     if GMSH_PATH is None:
         print("Gmsh not available for visualization.")
@@ -233,3 +234,4 @@ def enable_jupyter_viewer():
     import bempp_cl.api
 
     bempp_cl.api.PLOT_BACKEND = "jupyter_notebook"
+    

--- a/bempp_cl/api/external/viewers.py
+++ b/bempp_cl/api/external/viewers.py
@@ -1,6 +1,8 @@
 """Define interfaces to external viewers."""
 
 import numpy as _np
+import shutil
+import os
 
 
 def visualize(obj, mode=None, transformation=None):
@@ -153,18 +155,12 @@ def visualize_with_gmsh(obj, mode=None, transformation=None):
         )
     outfile.close()
 
-    ## important change for running of windows GUI
-    import shutil
-    import os
-
     gmsh_path = shutil.which("gmsh")
     env = os.environ.copy()
     if gmsh_path.lower().endswith(".bat"):
         subprocess.Popen(f'"{gmsh_path}" "{outfile.name}"', shell=True, env=env)
     else:
         subprocess.Popen([gmsh_path, outfile.name], env=env)
-
-    #subprocess.Popen([GMSH_PATH, outfile.name])
 
 
 def visualize_with_paraview(obj, mode=None, transformation=None):


### PR DESCRIPTION
We are developping software for charge particle optics simulation (efly) using bempp-cl. However, when we set up the gui for our softwar in windows system(Win10), the GMSH.exe cannot be launched due to the batch file (gmsh.bat) used to launch GMSH.exe in bempp for windows system. But, shell is not enabled by default. Therefore, part of the function visualize_with_gmsh(obj, mode=None, transformation=None) in viewer.py (bempp\api\external\viewer.py) should be modified to enable the shell. Afterwards, GMSH.exe can be launched automaticly after adding it to the system path.